### PR TITLE
ITB-170: Functional Authorization Filter

### DIFF
--- a/src/main/java/com/inthebytes/accountservice/SecurityConfig.java
+++ b/src/main/java/com/inthebytes/accountservice/SecurityConfig.java
@@ -15,6 +15,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import com.inthebytes.accountservice.login.AuthenticationFilter;
+import com.inthebytes.accountservice.login.AuthorizationFilter;
 import com.inthebytes.accountservice.service.LoginDetailsService;
 import com.inthebytes.accountservice.service.LogoutService;
 import org.springframework.web.cors.CorsConfiguration;
@@ -51,6 +52,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 	 	// Login
 		.and()
 	 	    .addFilter(new AuthenticationFilter(authenticationManager()))
+	 	    .addFilter(new AuthorizationFilter(authenticationManager()))
 			.authorizeRequests()
 			    .antMatchers("/admin/**").hasRole("ADMIN")
 		        .antMatchers( "/authenticated/**").authenticated()

--- a/src/main/java/com/inthebytes/accountservice/login/AuthorizationFilter.java
+++ b/src/main/java/com/inthebytes/accountservice/login/AuthorizationFilter.java
@@ -1,0 +1,75 @@
+package com.inthebytes.accountservice.login;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.auth0.jwt.interfaces.Verification;
+
+public class AuthorizationFilter extends BasicAuthenticationFilter {
+
+	public AuthorizationFilter(AuthenticationManager authenticationManager) {
+		super(authenticationManager);
+	}
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+			throws IOException, ServletException {
+		
+		String header = request.getHeader(JwtProperties.HEADER_STRING);
+		
+		if(header == null || !header.startsWith(JwtProperties.TOKEN_PREFIX)) {
+			chain.doFilter(request, response);
+			return;
+		}
+		
+		Authentication authentication = getAuthentication(request);
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+		
+		chain.doFilter(request, response);
+	}
+	
+	
+	private Authentication getAuthentication(HttpServletRequest request) {
+		String token = request.getHeader(JwtProperties.HEADER_STRING)
+				.replace(JwtProperties.TOKEN_PREFIX, "");
+		
+		if (token != null) {
+			DecodedJWT jwt = JWT.require(Algorithm.HMAC512(JwtProperties.SECRET))
+					.build()
+					.verify(token);
+			
+			String role = jwt.getClaim(JwtProperties.AUTHORITIES_KEY)
+					.asString();
+			
+			String userName = jwt.getSubject();
+			
+			if (role != null && userName != null) {
+				List<GrantedAuthority> authorities = new ArrayList<GrantedAuthority>();
+				GrantedAuthority authority = new SimpleGrantedAuthority(role);
+				authorities.add(authority);
+				UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(userName, null, authorities);
+				return auth;
+			}
+			return null;
+		}
+		return null;
+	}
+	
+}

--- a/src/main/java/com/inthebytes/accountservice/login/LoginPrincipal.java
+++ b/src/main/java/com/inthebytes/accountservice/login/LoginPrincipal.java
@@ -60,7 +60,7 @@ public class LoginPrincipal implements UserDetails {
 
 	@Override
 	public boolean isEnabled() {
-		return true;
+		return user.getActive();
 	}
 
 }

--- a/src/test/java/com/inthebytes/accountservice/control/RegistrationControllerTest.java
+++ b/src/test/java/com/inthebytes/accountservice/control/RegistrationControllerTest.java
@@ -1,0 +1,45 @@
+package com.inthebytes.accountservice.control;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.inthebytes.accountservice.controller.RegistrationController;
+import com.inthebytes.accountservice.service.ConfirmationService;
+import com.inthebytes.accountservice.service.RegistrationService;
+
+@WebMvcTest(RegistrationController.class)
+@AutoConfigureMockMvc
+public class RegistrationControllerTest {
+
+	@MockBean
+	RegistrationService service;
+
+	@MockBean
+	private ConfirmationService confirmationService;
+	
+	@Autowired
+	MockMvc mock;
+	
+	@Test
+	public void registerUser() {
+	}
+	
+	@Test
+	public void registerInvalidUser() {
+		
+	}
+
+	@Test
+	public void putUserConfirmation() {
+	}
+	
+	@Test
+	public void putInvalidUserConfirmation() {
+		
+	}
+
+}


### PR DESCRIPTION
Implemented and authorization filter that reads username and role from the JWT for matching granted authorities. Passes demo test with request header Authentication containing the JWT in format "Bearer [token]" (without quotes). 

Ensuring subsequent requests contain the authentication header provided from a valid POST request to "/login" should handled from the client-side UIs